### PR TITLE
Fix/debug maze tests

### DIFF
--- a/tests/test_maze.py
+++ b/tests/test_maze.py
@@ -46,8 +46,22 @@ def fill_with_zeros(solution_dict, n_rows, n_cols, ignore_list=None):
 
 
 def get_energy(solution_dict, bqm):
+    """Returns minimum possible energy over all possible auxiliary
+     configurations.
+    """
     min_energy = float('inf')
     aux_variables = [v for v in bqm.variables if re.match(r'aux\d+$', v)]
+
+    # Filter out irrelevant variables in solution_dict
+    # Note: some solution_dict keys may not contribute to the bqm at all, hence
+    #   we need to filter them out before applying `bqm.energy(..)`
+    irrelevant_variables = set(solution_dict.keys()) - set(bqm.variables)
+    for v in irrelevant_variables:
+        if solution_dict[v] == 0:
+            del solution_dict[v]
+        else:
+            raise RuntimeError(
+                "Input solution contains a nonzero var, therefore it is impossible for it to contribute to energy.")
 
     # Try all possible values of auxiliary variables
     for aux_values in itertools.product([0, 1], repeat=len(aux_variables)):

--- a/tests/test_maze.py
+++ b/tests/test_maze.py
@@ -58,9 +58,9 @@ def get_energy(solution_dict, bqm):
     irrelevant_variables = set(solution_dict.keys()) - set(bqm.variables)
     for v in irrelevant_variables:
         if solution_dict[v]:
-            raise RuntimeError(
-                "The variable, {}, has a nonzero expected value,".format(v),
-                "yet does not exist in the submitted BQM")
+            raise RuntimeError(("The variable, '{}', has a nonzero expected "
+                                "value, yet does not exist in the submitted "
+                                "BQM").format(v))
 
         # Safely delete non-contributing variable
         del solution_dict[v]

--- a/tests/test_maze.py
+++ b/tests/test_maze.py
@@ -57,11 +57,13 @@ def get_energy(solution_dict, bqm):
     #   we need to filter them out before applying `bqm.energy(..)`
     irrelevant_variables = set(solution_dict.keys()) - set(bqm.variables)
     for v in irrelevant_variables:
-        if solution_dict[v] == 0:
-            del solution_dict[v]
-        else:
+        if solution_dict[v]:
             raise RuntimeError(
-                "Input solution contains a nonzero var, therefore it is impossible for it to contribute to energy.")
+                "The variable, {}, has a nonzero expected value,".format(v),
+                "yet does not exist in the submitted BQM")
+
+        # Safely delete non-contributing variable
+        del solution_dict[v]
 
     # Try all possible values of auxiliary variables
     for aux_values in itertools.product([0, 1], repeat=len(aux_variables)):


### PR DESCRIPTION
**Why the error happened**
* bqm.energy(..) previously accepted key-value pairs, where the key did not exist in the bqm, but the value was 0, so everything was okay (SDK 1.6.0)
* this is no longer the case with the updated SDK (2.1.1) used by the maze repo

**Solution**
* filter out the variables that don't exist in the BQM
* note: I did think about making an issue to dimod about getting `bqm.energy` to ignore zeroed variables. However, after some thought, I realized that it shouldn't be part of the `bqm.energy(..)`'s job to catch my case.
