### PR TITLE
Tweak unit test for py35 compatibility

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -28,7 +28,7 @@ class IntegrationTests(unittest.TestCase):
         if os.getenv('DEBUG_OUTPUT'):
             print("Example output \n" + output)
 
-        with self.subTest(msg="Verify if output contains '0,1w':' \n"):
+        with self.subTest(msg="Verify if output contains \"'0,1w':\" \n"):
             self.assertIn("'0,1w':".upper(), output)
         with self.subTest(msg="Verify if error string contains in output \n"):
             self.assertNotIn("ERROR", output)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -28,8 +28,8 @@ class IntegrationTests(unittest.TestCase):
         if os.getenv('DEBUG_OUTPUT'):
             print("Example output \n" + output)
 
-        with self.subTest(msg="Verify if output contains '{'0,1w':' \n"):
-            self.assertIn("{'0,1w':".upper(), output)
+        with self.subTest(msg="Verify if output contains '0,1w':' \n"):
+            self.assertIn("'0,1w':".upper(), output)
         with self.subTest(msg="Verify if error string contains in output \n"):
             self.assertNotIn("ERROR", output)
         with self.subTest(msg="Verify if warning string contains in output \n"):


### PR DESCRIPTION
Check for "'0,1w'" in output instead of "{'0,1w'".  The latter can fail with py35 due to dictionaries not being ordered.  But there's really no need for the test to include the opening brace anyway.

Closes #9.